### PR TITLE
Fix goland alpine version + add SYSLOG_HOSTNAME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.15.10-alpine3.13 as build
 MAINTAINER michael@kth.se
 LABEL maintainer "michael@kth.se"
-ENV LOGSPOUT_VERSION=3.2.6
+ENV LOGSPOUT_VERSION=3.2.13
 RUN mkdir -p /go/src
 WORKDIR /go/src
 VOLUME /mnt/routes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as build
+FROM golang:1.15.10-alpine3.13 as build
 MAINTAINER michael@kth.se
 LABEL maintainer "michael@kth.se"
 ENV LOGSPOUT_VERSION=3.2.6
@@ -24,7 +24,7 @@ RUN echo 'import ( _ "github.com/gliderlabs/logspout/adapters/raw" )' >> /go/src
     && echo 'import ( _ "github.com/gliderlabs/logspout/transports/tls" )' >> /go/src/github.com/gliderlabs/logspout/modules.go \
     && echo 'import ( _ "github.com/gliderlabs/logspout/healthcheck" )' >> /go/src/github.com/gliderlabs/logspout/modules.go \
     && echo 'import ( _ "github.com/gliderlabs/logspout/adapters/multiline" )' >> /go/src/github.com/gliderlabs/logspout/modules.go \
-    && echo 'import ( _ "github.com/mictsi/logspout-gelf-1" )' >> /go/src/github.com/gliderlabs/logspout/modules.go
+    && echo 'import ( _ "github.com/mictsi/logspout-gelf-tls" )' >> /go/src/github.com/gliderlabs/logspout/modules.go
 
 RUN go get -d -v ./...
 RUN go build -v -ldflags "-X main.Version=$(cat VERSION)" -o ./bin/logspout


### PR DESCRIPTION
This PR does the following :

- Fix the goland alpine version. In the latest version, this error appears :  

```
go: cannot find main module, but found glide.lock in /go/src/github.com/gliderlabs/logspout
        to create a module there, run:
        go mod init
```

- Add swarm compatibility for the hostname (copied from the original logspout repository)
- Changed 
```
github.com/mictsi/logspout-gelf-1
```
to 
```
github.com/mictsi/logspout-gelf-tls
```
in the dependancies.

- Changed version to the last current version of logspout (3.2.13)