### PR TITLE
use /etc/host_hostname for setting hostname if available

### DIFF
--- a/gelf.go
+++ b/gelf.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -54,7 +55,13 @@ func debug(v ...interface{}) {
 }
 
 func getHostname() string {
-	hostname, _ = os.Hostname()
+	content, err := ioutil.ReadFile("/etc/host_hostname")
+	if err == nil && len(content) > 0 {
+		hostname = strings.TrimRight(string(content), "\r\n")
+	} else {
+		hostname, _ = os.Hostname()
+	}
+
 	return hostname
 
 }


### PR DESCRIPTION
Hi, this is a fix to use logspout in Swarm mode as specified in the upstream driver for Syslog: https://github.com/gliderlabs/logspout#using-logspout-in-a-swarm

In fact this is a port of functionality from that driver from upstream.
I tested it in my setup both with `/etc/hostname:/etc/host_hostname` mounted inside container (the inteded way for swarm mode) and without that (default mode) and in both cases the logspout worked as I'd expect that.

For testing out add the volume `/etc/hostname:/etc/host_hostname:ro` to your docker-compose file and see the field `host` in GELF output change to hostname of the host rather than ID of the container:
```
  logspout-gelf:
    image: erthad/logspout-gelf-tls
    volumes:
      - /etc/hostname:/etc/host_hostname:ro
      - /var/run/docker.sock:/var/run/docker.sock
```

